### PR TITLE
Add support for inheritable fiber locals (by default).

### DIFF
--- a/example/request.rb
+++ b/example/request.rb
@@ -1,0 +1,21 @@
+
+require_relative '../lib/fiber/local'
+
+require 'securerandom'
+
+module RequestID
+	extend Fiber::Local
+end
+
+Fiber.new do
+	RequestID.instance = SecureRandom.uuid
+	
+	pp RequestID.instance
+	
+	pp Fiber.current
+	
+	Fiber.new do
+		pp RequestID.instance
+	end.resume
+end.resume
+

--- a/lib/fiber/local/inheritable.rb
+++ b/lib/fiber/local/inheritable.rb
@@ -1,0 +1,41 @@
+
+require 'fiber'
+require 'securerandom'
+
+class Fiber
+	module Local
+		module Inheritable
+			def initialize(**options)
+				super(**options)
+				
+				self.inherit_attributes_from(Fiber.current)
+			end
+			
+			def self.prepended(klass)
+				klass.extend(Singleton)
+				klass.instance_variable_set(:@inheritable_attributes, Hash.new)
+			end
+			
+			module Singleton
+				def inheritable(key, default: nil)
+					@inheritable_attributes[:"@#{key}"] = default
+				end
+				
+				def inheritable_attributes
+					@inheritable_attributes
+				end
+			end
+			
+			def inherit_attributes_from(fiber)
+				self.class.inheritable_attributes.each do |name, default|
+					value = fiber.instance_variable_get(name) || default
+					self.instance_variable_set(name, value)
+				end
+			end
+		end
+	end
+end
+
+unless Fiber.respond_to?(:inheritable)
+	Fiber.prepend(Fiber::Local::Inheritable)
+end

--- a/spec/fiber/local/inheritable_spec.rb
+++ b/spec/fiber/local/inheritable_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright, 2021, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'fiber/local/inheritable'
+
+class MyFiber < Fiber
+	prepend Fiber::Local::Inheritable
+	
+	attr_accessor :id
+	inheritable :id
+end
+
+RSpec.describe Fiber::Local::Inheritable do
+	describe '.inheritable' do
+		it "can inherit id attribute" do
+			id = nil
+			
+			MyFiber.new do
+				Fiber.current.id = "testing123"
+				
+				MyFiber.new do
+					id = Fiber.current.id
+				end.resume
+			end.resume
+			
+			expect(id).to be == "testing123"
+		end
+	end
+end


### PR DESCRIPTION
## Description

As discussed here: https://github.com/socketry/falcon/discussions/142

Fiber concurrency sometimes requires request IDs to flow through to "nested" fibers. There are some cases where this doesn't make sense but generally, if a fiber has a local variable, e.g. `request_id`, it should be inherited by fibers created within that fiber. This allows systems like logging to track things like `request_id` through to different parts of a request, e.g. fan out HTTP RPC. There are other use cases, for example, sharing caches or persistent connections implicitly.

This change makes all `Fiber::Local`s inheritable by default. Here is a small example:

~~~ ruby
require_relative '../lib/fiber/local'
require 'securerandom'

module RequestID
	extend Fiber::Local
end

Fiber.new do
	RequestID.instance = SecureRandom.uuid
	
	pp RequestID.instance
	
	Fiber.new do
		pp RequestID.instance
	end.resume
end.resume
~~~

We could introduce default behaviour so that accessing an otherwise unset `RequestID.instance` fiber local would create **and** assign it to the current Fiber. That would make the contract more implicit, but I'm not sure that's desirable. If w did that, the above example could become this:

~~~ ruby
require_relative '../lib/fiber/local'
require 'securerandom'

module RequestID
	extend Fiber::Local

	def self.new
		SecureRandom.uuid
	end
end

Fiber.new do
	RequestID.instance # Internally call `.new` and assign it to current fiber
	
	pp RequestID.instance
	
	Fiber.new do
		pp RequestID.instance
	end.resume
end.resume
~~~

The benefit of this approach is that it makes the default implementation separate from the usage, but the cost is that we may end up accidentally creating fiber locals.

This change also introduces the following attribute mapping:

~~~ ruby
# Assuming the above implementation:
class Fiber
	attr_accessor :RequestID
end

class Thread
	attr_accessor :RequestID
end
~~~

At this time, I consider this an implementation detail - we may opt to change this to something more "canonical".

### Types of Changes

- New feature.
- (Semantics) Breaking change.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
